### PR TITLE
feat : booking show page

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -20,6 +20,12 @@ class BookingRequestsController < ApplicationController
   end
 
   def show
+    @booking = BookingRequest.find(params[:id])
+    if current_user.id == @booking.user_id
+      @flat = Flat.find(@booking.flat_id)
+    else
+      @flat = Flat.find_by(user_id: @booking.user_id)
+    end
   end
 
   # There should be a create, for when the Booking is sent and one update for when the

--- a/app/views/booking_requests/show.html.erb
+++ b/app/views/booking_requests/show.html.erb
@@ -1,0 +1,1 @@
+<%= @flat.address %>

--- a/app/views/booking_requests/show.html.erb
+++ b/app/views/booking_requests/show.html.erb
@@ -1,1 +1,2 @@
+<%= cl_image_tag @flat.photos.first.key %>
 <%= @flat.address %>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -20,6 +20,8 @@
             <div class="col-2">
               <% if booking.stay_status == BookingRequest::TB_PAID || booking.stay_status == BookingRequest::TBP_REQUESTER %>
                 <%= link_to "pay", confirm_booking_path(booking)%>
+              <% elsif booking.status == BookingRequest::ACCEPTED && booking.stay_status == BookingRequest::UPCOMING %>
+                <%= link_to "View", booking_request_path(booking), class: "btn-db rounded-pill border-0 w-100 py-3" %>
               <% end %>
             </div>
           </div>
@@ -46,7 +48,9 @@
                 <%= link_to "Accept", accept_booking_path(booking), method: :patch, class: "btn-db rounded-pill border-0 w-100 py-3" %>
                 <%= link_to "Decline", decline_booking_path(booking), method: :delete, data: { confirm: "Are you sure?" }, class: "btn-db rounded-pill border-0 w-100 py-3" %>
               <% elsif booking.status == BookingRequest::DECLINED && booking.stay_status == BookingRequest::CANCELLED %>
-              <p>Declined<p>
+                <p>Declined<p>
+              <% elsif booking.status == BookingRequest::ACCEPTED && booking.stay_status == BookingRequest::UPCOMING %>
+                <%= link_to "View", booking_request_path(booking), class: "btn-db rounded-pill border-0 w-100 py-3" %>
               <% elsif booking.stay_status == BookingRequest::TB_PAID || booking.stay_status == BookingRequest::TBP_OWNER%>
                 <%= link_to "pay", confirm_booking_path(booking), class: "btn-db rounded-pill border-0 w-100 py-3 "%>
               <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,5 @@ Rails.application.routes.draw do
     resources :amenities, only: %i[new create]
   end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  resources :booking_requests, only: :show
 end


### PR DESCRIPTION
So guys,
now after the two users accept the requestes and pay, they will see a "view button" in their dashbord next to the booking

![image](https://user-images.githubusercontent.com/90606268/156892973-fe4ede86-5873-4e52-8873-b3e33e0f4bee.png)

if they click on it they will be redirect to the "booking show page", that will show them the details of the flat they are going to

![image](https://user-images.githubusercontent.com/90606268/156893019-40924e99-3efe-4be7-b6fe-e9ccefcddbc2.png)

we can put whatever we want in here releted to the flat, right now (as you can see) I only put the photo and the address just to show something..the front end is missing hehe