### PR TITLE
link on navbar corrected

### DIFF
--- a/app/views/components/_navbar.html.erb
+++ b/app/views/components/_navbar.html.erb
@@ -26,7 +26,7 @@
       </li>
     <% end %>
     <li>
-      <%= link_to "Chats",chat_rooms_path, class: "nav-item" %>
+      <%= link_to "Chats",flat_chat_room_path(current_user.flats.first, current_user.flats.first.chat_rooms.first), class: "nav-item" %>
     </li>
     <li>
       <%= link_to "Dashboard", dashboard_path, class: "nav-btn", style: "text-decoration: none;"%>


### PR DESCRIPTION
The link to chats on the navbar has been corrected to the actual chats page. 