### PR TITLE
bugfix front-end: reviews, flat summary and chats

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -60,10 +60,20 @@
   width: 40px;
 }
 
+.reviews-container{
+  white-space: nowrap;
+  overflow-x: auto;
+  height: auto;
+  width: 100%;
+}
+
 .review-card {
-  display: flex;
+  display: inline-block;
   flex-direction: column;
-  position: relative;
+  // position: relative;
+  height: 400px;
+  width: 250px;
+  overflow: hidden;
 
   .avatar-review {
   width: 50px;
@@ -74,8 +84,12 @@
   }
 
   p {
-    margin-top: 7px;
-    margin-left: 24px;
+    //margin: 7px 5px;
+    // margin-left: 5px;
+    width: 200px;
+    word-wrap: break-word;
+    // white-space: pre-wrap;
+    //display: inline;
   }
 
   h5 {

--- a/app/assets/stylesheets/components/_messages.scss
+++ b/app/assets/stylesheets/components/_messages.scss
@@ -1,6 +1,6 @@
 #messages {
   overflow-y: auto;
-  height: 300px;
+  height: 500px;
 }
 
 .message-container {

--- a/app/views/chat_rooms/show.html.erb
+++ b/app/views/chat_rooms/show.html.erb
@@ -13,7 +13,7 @@
 
 
 <div class="d-flex Mle" >
-  <div class="flex-shrink-1" style="border-right: 1px solid #c4c4c4; margin-left:-0.5px;">
+  <div class="flex-shrink-1 overflow-auto" style="border-right: 1px solid #c4c4c4; margin-left:-0.5px;">
     <div class="" id = "chat-cards">
       <% @chat_rooms.each_with_index do |chat, i| %>
         <% if chat.flat.user_id == current_user.id%>

--- a/app/views/components/_chat_bubble.html.erb
+++ b/app/views/components/_chat_bubble.html.erb
@@ -10,7 +10,11 @@
       <img class="avatar-large" alt="avatar-large" src="https://miro.medium.com/max/720/1*W35QUSvGpcLuxPo3SRTH4w.png">
     <% end %>
     <div class="chat-info">
-      <p class="f14"> <%= user.first_name %> <span class="selected-color"> • <%= user.flats.first.city %></span></p>
+      <% flat = user.flats.first %>
+      <% text = "#{flat.name.split(" ")[0]} #{flat.name.split(" ")[1]}.." %>
+      <%= link_to flat_path(flat), class:"noDeco2" do %>
+        <p class="f14"> <%= text %> <span class="selected-color"> • <%= user.flats.first.city %></span></p>
+      <% end %>
       <p> <% last_message = chat.messages.last %>
       <% if last_message&.created_at&.to_date == Date.current %>
         <p  class="pB10"><span class="message-info selected-color">Last Message: today </span></p>

--- a/app/views/components/_reviews.html.erb
+++ b/app/views/components/_reviews.html.erb
@@ -1,9 +1,9 @@
 
 <% if @reviews.present? %>
   <div class="f24 pT alignC" ><%= image_tag "star_big.png", class: "pT5b"%> <p style="display: inline;"> <%= @flat.review_average%> - <%= @flat.reviews.count%> reviews </p> </div>
-    <div class="grid3">
+    <div class="reviews-container">
       <% @flat.reviews.each do |review| %>
-        <div class="review-card d-flex">
+        <div class="review-card">
           <p> <%= cl_image_tag review.booking_request.user.photo.key, class: "avatar-review mr-2" %>
           <%= review.booking_request.user.first_name%></p>
           <div style="padding-left:20px;">
@@ -11,7 +11,7 @@
               <i class="fa-solid fa-star" style=" display: inline-block;"></i>
             <% end %>
           </div>
-          <p><%= review.content %></p>
+          <p class="text-wrap"><%= review.content %></p>
 
 
         </div>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -19,7 +19,7 @@
         <% end %>
       </ul>
 </div>
-    <div class="align-self-end">
+    <div class="align-self-baseline">
       <%= render 'components/flat_summary', flat: @user.flats.first %>
     </div>
   </div>


### PR DESCRIPTION
Please do not merge without discussing it with the group. 
Now the app: 
Reviews move horizontally with a scroll, inline configuration. 
Flat summary doesn't go down anymore, corrected. 
Chat changed to display first two words of the flat, and has a link to the corresponding flat on the card. 
Size of the Chat display augmented so input messages is down as requested. 

![Screenshot 2022-03-19 at 08 27 35](https://user-images.githubusercontent.com/90617385/159111964-97ca02a7-1a45-453e-88b0-fb67bc020f1f.png)
![Screenshot 2022-03-19 at 08 30 15](https://user-images.githubusercontent.com/90617385/159112042-0fa7a6b2-2900-4cf7-bd8d-6f19cfd459b4.png)
![Screenshot 2022-03-19 at 08 30 33](https://user-images.githubusercontent.com/90617385/159112045-841402cf-3565-44b6-9737-57c76da31600.png)

